### PR TITLE
Branch protection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,8 +188,6 @@ jobs:
     name: Build Succeeded Overall
     if: always()
     needs:
-      - build_llvm_windows
-      - build_llvm_linux
       - build_package_windows
       - build_package_linux
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,3 +181,20 @@ jobs:
         with:
           name: package-${{ env.image_key }}-deb
           path: build/gcc-release/clang-format-autoversion_*_amd64.deb
+
+  # This job does nothing and is only used for the branch protection
+  # See https://github.com/orgs/community/discussions/26733?sort=top#discussioncomment-3253155
+  build_overall:
+    name: Build Succeeded Overall
+    if: always()
+    needs:
+      - build_llvm_windows
+      - build_llvm_linux
+      - build_package_windows
+      - build_package_linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Add a final "check" job to the workflow that succeeds if all upstream jobs succeeded (and were not skipped). This makes it easier to configure the branch protection rules in GitHub - as it only allows marking _specific_ jobs as required, instead of letting us require _all_ jobs.

More info as to why this is required: https://github.com/orgs/community/discussions/26733?sort=top#discussioncomment-3253155